### PR TITLE
[iOS] Complete the minimum implementation for the package verb.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/ProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/ProcessManager.cs
@@ -14,6 +14,9 @@ using Microsoft.DotNet.XHarness.iOS.Shared.Execution.Mlaunch;
 
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Execution {
 	public class ProcessManager : IProcessManager {
+		private static string xcodeDefaultPath = "/Applications/Xcode.app";
+		private static string mlaunchDefaultPath = "/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mlaunch";
+
 		public string XcodeRoot { get; }
 		public string MlaunchPath { get; }
 
@@ -27,6 +30,10 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Execution {
 				}
 				return xcode_version;
 			}
+		}
+
+ 		public ProcessManager () : this (xcodeDefaultPath, mlaunchDefaultPath)
+		{ 
 		}
 
 		public ProcessManager (string xcodeRoot, string mlaunchPath)


### PR DESCRIPTION
Not fully completed, but the verb now creates a fully working app that
can be executed in a simulator or a device to run the tests.

Command calls nuget restore and msbuild. We should move this to its own task
classes like in xamarin-macios, but it is a good first implementation
for a POC.