### PR TITLE
[iOS] Provide the basic xUnit iOS runner.

### DIFF
--- a/XHarness.sln
+++ b/XHarness.sln
@@ -23,6 +23,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.XHarness.i
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.XHarness.iOS.Shared", "src\Microsoft.DotNet.XHarness.iOS.Shared\Microsoft.DotNet.XHarness.iOS.Shared.csproj", "{232CACB5-9A92-437B-9196-FAEB19B6B542}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.XHarness.iOS.TestRunner", "src\Microsoft.DotNet.XHarness.iOS.TestRunner\Microsoft.DotNet.XHarness.iOS.TestRunner.csproj", "{3CA162C4-C0B4-4FC0-A1A7-C7BBEC061069}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{232CACB5-9A92-437B-9196-FAEB19B6B542}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{232CACB5-9A92-437B-9196-FAEB19B6B542}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{232CACB5-9A92-437B-9196-FAEB19B6B542}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3CA162C4-C0B4-4FC0-A1A7-C7BBEC061069}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3CA162C4-C0B4-4FC0-A1A7-C7BBEC061069}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3CA162C4-C0B4-4FC0-A1A7-C7BBEC061069}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3CA162C4-C0B4-4FC0-A1A7-C7BBEC061069}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -54,6 +60,7 @@ Global
 		{62B9CF6B-2263-42F8-AD0F-4ED52E25C097} = {1018BF4C-BD8F-49D7-9797-758E68B9FC9D}
 		{028958FF-2795-4678-803D-AE16F8528FCC} = {713ACDCF-301D-4C96-8B75-5BF2A35A326D}
 		{232CACB5-9A92-437B-9196-FAEB19B6B542} = {713ACDCF-301D-4C96-8B75-5BF2A35A326D}
+		{3CA162C4-C0B4-4FC0-A1A7-C7BBEC061069} = {713ACDCF-301D-4C96-8B75-5BF2A35A326D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {56D5F4DA-F710-4026-8F49-4A903BCAA9B5}

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/ApplicationOptions.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/ApplicationOptions.cs
@@ -1,0 +1,101 @@
+// Modified version of the TouchOptions found in 
+using System;
+using Mono.Options;
+
+namespace Microsoft.DotNet.XHarness.iOS.TestRunner
+{ 
+	
+	public enum XmlMode {
+		Default = 0,
+		Wrapped = 1,
+	}
+
+	public enum XmlVersion {
+		NUnitV2 = 0,
+		NUnitV3 = 1,
+	}
+
+	public class ApplicationOptions {
+
+		static public ApplicationOptions Current = new ApplicationOptions ();
+		
+		public ApplicationOptions ()
+		{
+			bool b;
+			if (bool.TryParse (Environment.GetEnvironmentVariable ("NUNIT_AUTOEXIT"), out b))
+				TerminateAfterExecution = b;
+			if (bool.TryParse (Environment.GetEnvironmentVariable ("NUNIT_AUTOSTART"), out b))
+				AutoStart = b;
+			if (bool.TryParse (Environment.GetEnvironmentVariable ("NUNIT_ENABLE_NETWORK"), out b))
+				EnableNetwork = b;
+			if (!string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("NUNIT_HOSTNAME")))
+				HostName = Environment.GetEnvironmentVariable ("NUNIT_HOSTNAME");
+			int i;
+			if (int.TryParse (Environment.GetEnvironmentVariable ("NUNIT_HOSTPORT"), out i))
+				HostPort = i;
+			if (bool.TryParse (Environment.GetEnvironmentVariable ("NUNIT_SORTNAMES"), out b))
+				SortNames = b;
+			if (!string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("NUNIT_TRANSPORT")))
+				Transport = Environment.GetEnvironmentVariable ("NUNIT_TRANSPORT");
+			if (bool.TryParse (Environment.GetEnvironmentVariable ("NUNIT_ENABLE_XML_OUTPUT"), out b))
+				EnableXml = b;
+			var xml_mode = Environment.GetEnvironmentVariable ("NUNIT_ENABLE_XML_MODE");
+			if (!string.IsNullOrEmpty (xml_mode))
+				XmlMode = (XmlMode) Enum.Parse (typeof (XmlMode), xml_mode, true);
+			var xml_version = Environment.GetEnvironmentVariable ("NUNIT_XML_VERSION");
+			if (!string.IsNullOrEmpty (xml_version))
+				XmlVersion = (XmlVersion)Enum.Parse (typeof (XmlVersion), xml_version, true);
+			if (!string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("NUNIT_LOG_FILE")))
+				LogFile = Environment.GetEnvironmentVariable ("NUNIT_LOG_FILE");
+
+			var os = new OptionSet () {
+				{ "autoexit", "If the app should exit once the test run has completed.", v => TerminateAfterExecution = true },
+				{ "autostart", "If the app should automatically start running the tests.", v => AutoStart = true },
+				{ "hostname=", "Comma-separated list of host names or IP address to (try to) connect to", v => HostName = v },
+				{ "hostport=", "HTTP/TCP port to connect to.", v => HostPort = int.Parse (v) },
+				{ "enablenetwork", "Enable the network reporter.", v => EnableNetwork = true },
+				{ "transport=", "Select transport method. Either TCP (default), HTTP or FILE.", v => Transport = v },
+				{ "enablexml", "Enable the xml reported.", v => EnableXml = false },
+				{ "xmlmode", "The xml mode.", v => XmlMode = (XmlMode) Enum.Parse (typeof (XmlMode), v, false) },
+				{ "xmlversion", "The xml version.", v => XmlVersion = (XmlVersion) Enum.Parse (typeof (XmlVersion), v, false) },
+				{ "logfile=", "A path where output will be saved.", v => LogFile = v },
+				{ "result=", "The path to be used to store the result", v => ResultFile = v},
+			};
+			
+			try {
+				os.Parse (Environment.GetCommandLineArgs ());
+			} catch (OptionException oe) {
+				Console.WriteLine ("{0} for options '{1}'", oe.Message, oe.OptionName);
+			}
+		}
+		
+		private bool EnableNetwork { get; set; }
+
+		public XmlMode XmlMode { get; set; }
+
+		public XmlVersion XmlVersion { get; set; } = XmlVersion.NUnitV2;
+
+		public bool EnableXml { get; set; }
+		
+		public string HostName { get; private set; }
+		
+		public int HostPort { get; private set; }
+		
+		public bool AutoStart { get; set; }
+		
+		public bool TerminateAfterExecution { get; set; }
+		
+		public string Transport { get; set; } = "TCP";
+
+		public string LogFile { get; set; }
+		
+		public string ResultFile { get; set; }
+
+		public bool ShowUseNetworkLogger {
+			get { return EnableNetwork && !string.IsNullOrWhiteSpace (HostName) && (HostPort > 0 || Transport == "FILE"); }
+		}
+
+		public bool SortNames { get; set; }
+
+	}
+}

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/ApplicatonEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/ApplicatonEntryPoint.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.DotNet.XHarness.iOS.TestRunner.Core;
+using Microsoft.DotNet.XHarness.iOS.TestRunner.XUnit;
+
+namespace Microsoft.DotNet.XHarness.iOS.TestRunner
+{
+    public enum TestRunner
+    {
+        NUnit,
+        xUnit,
+    }
+
+    /// <summary>
+    /// Abstract class that represents the entry point of the test application.
+    /// 
+    /// Subclasses most provide the minimun implementation to ensure that:
+    ///
+    /// Device: We do have the required device information for the logger.
+    /// Asseblies: Provide a list of the assembly information to be ran.
+    ///     assemblies can be loaded from disk or from memory, is up to the 
+    ///     implementator.
+    /// </summary>
+    public abstract class ApplicatonEntryPoint
+    {
+        /// <summary>
+        /// Must be implemented and return a class that returns the information
+        /// of a device. It can return null.
+        /// </summary>
+        protected abstract IDevice Device { get; }
+
+        /// <summary>
+        /// Returns the IENumerable with the asseblies that contain the tests
+        /// to be ran.
+        /// </summary>
+        /// <returns></returns>
+        protected abstract IEnumerable<TestAssemblyInfo> GetTestAssemblies();
+
+        /// <summary>
+        /// Returns the type of runner to use.
+        /// </summary>
+        protected abstract TestRunner TestRunner { get; }
+
+        /// <summary>
+        /// Returns the directory that contains the ignore files.
+        /// </summary>
+        protected abstract string IgnoreFilesDirectory { get; }
+
+        /// <summary>
+        /// Terminates the application. This should ensure that it is executed
+        /// in the main thread.
+        /// </summary>
+        protected abstract void TerminateWithSuccess();
+
+        public async Task RunAsync()
+        {
+            var options = ApplicationOptions.Current;
+            TcpTextWriter writer = null;
+            if (!string.IsNullOrEmpty(options.HostName))
+            {
+                try
+                {
+                    writer = new TcpTextWriter(options.HostName, options.HostPort);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine("Network error: Cannot connect to {0}:{1}: {2}. Continuing on console.", options.HostName, options.HostPort, ex);
+                    writer = null; // will default to the console
+                }
+            }
+
+            // we generate the logs in two different ways depending if the generate xml flag was
+            // provided. If it was, we will write the xml file to the tcp writer if present, else
+            // we will write the normal console output using the LogWriter
+            var logger = (writer == null || options.EnableXml) ? new LogWriter(Device) : new LogWriter(Device, writer);
+            logger.MinimumLogLevel = MinimumLogLevel.Info;
+            var testAssemblies = GetTestAssemblies();
+            Core.TestRunner runner;
+            switch (TestRunner) {
+                case TestRunner.NUnit:
+                    throw new NotImplementedException("The NUnit test runner has not yet been implemened.");
+                default:
+                    runner = new XUnitTestRunner(logger);
+                    break;
+			}
+
+            if (!string.IsNullOrEmpty(IgnoreFilesDirectory))
+            {
+                var categories = await IgnoreFileParser.ParseTraitsContentFileAsync(IgnoreFilesDirectory, TestRunner == TestRunner.xUnit);
+                // add category filters if they have been added
+                runner.SkipCategories(categories);
+
+				var skippedTests = await IgnoreFileParser.ParseContentFilesAsync(IgnoreFilesDirectory);
+				if (skippedTests.Any())
+				{
+					// ensure that we skip those tests that have been passed via the ignore files
+					runner.SkipTests(skippedTests);
+				}
+            }
+
+            // if we have ignore files, ignore those tests
+            await runner.Run(testAssemblies).ConfigureAwait(false);
+
+            Core.TestRunner.Jargon jargon = Core.TestRunner.Jargon.NUnitV3;
+            switch (options.XmlVersion)
+            {
+                case XmlVersion.NUnitV2:
+                    jargon = Core.TestRunner.Jargon.NUnitV2;
+                    break;
+                case XmlVersion.NUnitV3:
+                default: // nunitv3 gives os the most amount of possible details
+                    jargon = Core.TestRunner.Jargon.NUnitV3;
+                    break;
+            }
+            if (options.EnableXml)
+            {
+                runner.WriteResultsToFile(writer ?? Console.Out, jargon);
+                logger.Info("Xml file was written to the tcp listener.");
+            }
+            else
+            {
+                string resultsFilePath = runner.WriteResultsToFile(jargon);
+                logger.Info($"Xml result can be found {resultsFilePath}");
+            }
+
+            logger.Info($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests}");
+            if (options.TerminateAfterExecution)
+                TerminateWithSuccess();
+        }
+
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/ApplicatonEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/ApplicatonEntryPoint.cs
@@ -25,6 +25,7 @@ namespace Microsoft.DotNet.XHarness.iOS.TestRunner
     /// </summary>
     public abstract class ApplicatonEntryPoint
     {
+        protected abstract int? MaxParallelThreads { get; }
         /// <summary>
         /// Must be implemented and return a class that returns the information
         /// of a device. It can return null.
@@ -78,13 +79,17 @@ namespace Microsoft.DotNet.XHarness.iOS.TestRunner
             logger.MinimumLogLevel = MinimumLogLevel.Info;
             var testAssemblies = GetTestAssemblies();
             Core.TestRunner runner;
-            switch (TestRunner) {
+            switch (TestRunner)
+            {
                 case TestRunner.NUnit:
                     throw new NotImplementedException("The NUnit test runner has not yet been implemened.");
                 default:
-                    runner = new XUnitTestRunner(logger);
+                    runner = new XUnitTestRunner(logger)
+                    {
+                        MaxParallelThreads = MaxParallelThreads
+                    };
                     break;
-			}
+            }
 
             if (!string.IsNullOrEmpty(IgnoreFilesDirectory))
             {
@@ -92,12 +97,12 @@ namespace Microsoft.DotNet.XHarness.iOS.TestRunner
                 // add category filters if they have been added
                 runner.SkipCategories(categories);
 
-				var skippedTests = await IgnoreFileParser.ParseContentFilesAsync(IgnoreFilesDirectory);
-				if (skippedTests.Any())
-				{
-					// ensure that we skip those tests that have been passed via the ignore files
-					runner.SkipTests(skippedTests);
-				}
+                var skippedTests = await IgnoreFileParser.ParseContentFilesAsync(IgnoreFilesDirectory);
+                if (skippedTests.Any())
+                {
+                    // ensure that we skip those tests that have been passed via the ignore files
+                    runner.SkipTests(skippedTests);
+                }
             }
 
             // if we have ignore files, ignore those tests

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/Extensions.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/Extensions.cs
@@ -1,0 +1,10 @@
+﻿namespace Microsoft.DotNet.XHarness.iOS.TestRunner.Core
+{
+    public static partial class Extensions
+    {
+        public static string YesNo(this bool b)
+        {
+            return b ? "yes" : "no";
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/IDevice.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/IDevice.cs
@@ -1,0 +1,18 @@
+﻿namespace Microsoft.DotNet.XHarness.iOS.TestRunner.Core
+{
+    /// <summary>
+    /// Interface to be implemented by those classes that provide the required
+    /// information of the device that is being used so that we can add the
+    /// device information in the test logs.
+    /// </summary>
+    public interface IDevice
+    {
+        string BundleIdentifier { get; }
+        string UniqueIdentifier { get; }
+        string Name { get; }
+        string Model { get; }
+        string SystemName { get; }
+        string SystemVersion { get; }
+        string Locale { get; }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/LogWriter.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/LogWriter.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.IO;
+
+namespace Microsoft.DotNet.XHarness.iOS.TestRunner.Core
+{
+    public class LogWriter
+    {
+        TextWriter writer;
+        IDevice device;
+
+        public MinimumLogLevel MinimumLogLevel { get; set; } = MinimumLogLevel.Info;
+
+        public LogWriter() : this(null, Console.Out) { }
+
+        public LogWriter(IDevice device) : this(device, Console.Out) { }
+
+        public LogWriter(TextWriter w) : this(null, w) { }
+
+        public LogWriter(IDevice device, TextWriter writer) 
+        {
+            this.writer = writer ?? Console.Out;
+            this.device = device;
+            if (this.device != null) // we just write the header if we do have the device info
+                InitLogging();
+        }
+
+        [System.Runtime.InteropServices.DllImport("/usr/lib/libobjc.dylib")]
+        static extern IntPtr objc_msgSend(IntPtr receiver, IntPtr selector);
+
+        public void InitLogging()
+        {
+            // print some useful info
+            writer.WriteLine("[Runner executing:\t{0}]", "Run everything");
+            writer.WriteLine("[{0}:\t{1} v{2}]", device.Model, device.SystemName, device.SystemVersion);
+            writer.WriteLine("[Device Name:\t{0}]", device.Name);
+            writer.WriteLine("[Device UDID:\t{0}]", device.UniqueIdentifier);
+            writer.WriteLine("[Device Locale:\t{0}]", device.Locale);
+            writer.WriteLine("[Device Date/Time:\t{0}]", DateTime.Now); // to match earlier C.WL output
+            writer.WriteLine("[Bundle:\t{0}]", device.BundleIdentifier);
+        }
+        public void OnError(string message)
+        {
+            if (MinimumLogLevel < MinimumLogLevel.Error)
+                return;
+            writer.WriteLine(message);
+            writer.Flush();
+        }
+
+        public void OnWarning(string message)
+        {
+            if (MinimumLogLevel < MinimumLogLevel.Warning)
+                return;
+            writer.WriteLine(message);
+            writer.Flush();
+        }
+
+        public void OnDebug(string message)
+        {
+            if (MinimumLogLevel < MinimumLogLevel.Debug)
+                return;
+            writer.WriteLine(message);
+            writer.Flush();
+        }
+
+        public void OnDiagnostic(string message)
+        {
+            if (MinimumLogLevel < MinimumLogLevel.Verbose)
+                return;
+            writer.WriteLine(message);
+            writer.Flush();
+        }
+
+        public void OnInfo(string message)
+        {
+            if (MinimumLogLevel < MinimumLogLevel.Info)
+                return;
+            writer.WriteLine(message);
+            writer.Flush();
+        }
+
+        public void Info(string message)
+        {
+            writer.WriteLine(message);
+            writer.Flush();
+        }
+
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/MinimumLogLevel.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/MinimumLogLevel.cs
@@ -1,0 +1,12 @@
+﻿namespace Microsoft.DotNet.XHarness.iOS.TestRunner.Core
+{
+    public enum MinimumLogLevel
+    {
+        Critical,
+        Error,
+        Warning,
+        Info,
+        Debug,
+        Verbose
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/TcpTextWriter.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/TcpTextWriter.cs
@@ -1,0 +1,144 @@
+﻿// this is an adaptation of NUnitLite's TcpWriter.cs with an additional 
+// overrides and with network-activity UI enhancement
+// This code is a small modification of 
+// https://github.com/spouliot/Touch.Unit/blob/master/NUnitLite/TouchRunner/TcpTextWriter.cs
+using System;
+using System.IO;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+
+namespace Microsoft.DotNet.XHarness.iOS.TestRunner.Core
+{
+    public class TcpTextWriter : TextWriter
+    {
+
+        TcpClient client;
+        StreamWriter writer;
+
+        static string SelectHostName(string[] names, int port)
+        {
+            if (names.Length == 0)
+                return null;
+
+            if (names.Length == 1)
+                return names[0];
+
+            object lock_obj = new object();
+            string result = null;
+            int failures = 0;
+
+            using (var evt = new ManualResetEvent(false))
+            {
+                for (int i = names.Length - 1; i >= 0; i--)
+                {
+                    var name = names[i];
+                    ThreadPool.QueueUserWorkItem((v) =>
+                       {
+                           try
+                           {
+                               var client = new TcpClient(name, port);
+                               using (var writer = new StreamWriter(client.GetStream()))
+                               {
+                                   writer.WriteLine("ping");
+                               }
+                               lock (lock_obj)
+                               {
+                                   if (result == null)
+                                       result = name;
+                               }
+                               evt.Set();
+                           }
+                           catch (Exception)
+                           {
+                               lock (lock_obj)
+                               {
+                                   failures++;
+                                   if (failures == names.Length)
+                                       evt.Set();
+                               }
+                           }
+                       });
+                }
+
+                // Wait for 1 success or all failures
+                evt.WaitOne();
+            }
+
+            return result;
+        }
+
+        public TcpTextWriter(string hostName, int port)
+        {
+            if ((port < 0) || (port > ushort.MaxValue))
+                throw new ArgumentOutOfRangeException(nameof(port), $"Port must be between 0 and {ushort.MaxValue}");
+
+            if (hostName == null)
+                throw new ArgumentNullException(nameof(hostName));
+            HostName = SelectHostName(hostName.Split(','), port);
+            Port = port;
+
+            try
+            {
+                client = new TcpClient(HostName, port);
+                writer = new StreamWriter(client.GetStream());
+            }
+            catch
+            {
+                throw;
+            }
+        }
+
+        public string HostName { get; private set; }
+
+        public int Port { get; private set; }
+
+        // we override everything that StreamWriter overrides from TextWriter
+
+        public override System.Text.Encoding Encoding => Encoding.UTF8;
+
+        public override void Close()
+        {
+            writer.Close();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            writer.Dispose();
+        }
+
+        public override void Flush()
+        {
+            writer.Flush();
+        }
+
+        // minimum to override - see http://msdn.microsoft.com/en-us/library/system.io.textwriter.aspx
+        public override void Write(char value)
+        {
+            writer.Write(value);
+        }
+
+        public override void Write(char[] buffer)
+        {
+            writer.Write(buffer);
+        }
+
+        public override void Write(char[] buffer, int index, int count)
+        {
+            writer.Write(buffer, index, count);
+        }
+
+        public override void Write(string value)
+        {
+            writer.Write(value);
+        }
+
+        // special extra override to ensure we flush data regularly
+
+        public override void WriteLine()
+        {
+            writer.WriteLine();
+            writer.Flush();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/TcpTextWriter.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/TcpTextWriter.cs
@@ -78,16 +78,9 @@ namespace Microsoft.DotNet.XHarness.iOS.TestRunner.Core
             HostName = SelectHostName(hostName.Split(','), port);
             Port = port;
 
-            try
-            {
-                client = new TcpClient(HostName, port);
-                writer = new StreamWriter(client.GetStream());
-            }
-            catch
-            {
-                throw;
-            }
-        }
+            client = new TcpClient(HostName, port);
+            writer = new StreamWriter(client.GetStream());
+       }
 
         public string HostName { get; private set; }
 

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/TestAssemblyInfo.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/TestAssemblyInfo.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Reflection;
+
+namespace Microsoft.DotNet.XHarness.iOS.TestRunner.Core
+{
+    public class TestAssemblyInfo
+    {
+        public Assembly Assembly { get; }
+        public string FullPath { get; }
+
+        public TestAssemblyInfo(Assembly assembly, string fullPath)
+        {
+            Assembly = assembly ?? throw new ArgumentNullException(nameof(assembly));
+            FullPath = fullPath ?? string.Empty;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/TestCompletionStatus.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/TestCompletionStatus.cs
@@ -1,0 +1,11 @@
+﻿namespace Microsoft.DotNet.XHarness.iOS.TestRunner.Core
+{
+    public enum TestCompletionStatus
+    {
+        Undefined,
+        Passed,
+        Failed,
+        Skipped,
+        Inconclusive,
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/TestExecutionState.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/TestExecutionState.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace Microsoft.DotNet.XHarness.iOS.TestRunner.Core
+{
+    public class TestExecutionState
+    {
+        public string TestName { get; internal set; }
+        public TimeSpan Started { get; private set; } = TimeSpan.MinValue;
+        public TimeSpan Finished { get; private set; } = TimeSpan.MinValue;
+        public TestCompletionStatus CompletionStatus { get; set; } = TestCompletionStatus.Undefined;
+
+        internal TestExecutionState() { }
+
+        internal void Start()
+        {
+            Started = new TimeSpan(DateTime.Now.Ticks);
+        }
+
+        internal void Finish()
+        {
+            Finished = new TimeSpan(DateTime.Now.Ticks);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/TestFailureInfo.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/TestFailureInfo.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace Microsoft.DotNet.XHarness.iOS.TestRunner.Core
+{
+    /// <summary>
+    /// Contains information about a single test failure. Information is used at the end of the run to print
+    /// summary of failures to logcat as well as put them in the results Bundle. <see cref="TestName"/> is used
+    /// only to generate unique index when storing information in the Bundle, so <see cref="Message"/> must contain
+    /// the test name.
+    /// </summary>
+    public class TestFailureInfo
+    {
+        /// <summary>
+        /// Gets or sets the name of the test. Must not be null or empty (all whitespace isn't allowed either)
+        /// </summary>
+        /// <value>The name of the test.</value>
+        public string TestName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the message.
+        /// </summary>
+        /// <value>The message.</value>
+        public string Message { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether this <see cref="T:Xamarin.Android.UnitTests.TestFailureInfo"/> has info 
+        /// about failure.
+        /// </summary>
+        /// <value><c>true</c> info exists; otherwise, <c>false</c>.</value>
+        public bool HasInfo => !String.IsNullOrEmpty(TestName?.Trim()) && !String.IsNullOrEmpty(Message);
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/TestRunSelector.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/TestRunSelector.cs
@@ -1,0 +1,10 @@
+namespace Microsoft.DotNet.XHarness.iOS.TestRunner.Core
+{
+    public class TestRunSelector
+    {
+        public string Assembly { get; set; }
+        public string Value { get; set; }
+        public TestRunSelectorType Type { get; set; }
+        public bool Include { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/TestRunSelectorType.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/TestRunSelectorType.cs
@@ -1,0 +1,10 @@
+namespace Microsoft.DotNet.XHarness.iOS.TestRunner.Core
+{
+    public enum TestRunSelectorType
+    {
+        Assembly,
+        Namespace,
+        Class,
+        Single,
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/TestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Core/TestRunner.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+
+
+namespace Microsoft.DotNet.XHarness.iOS.TestRunner.Core
+{
+    public abstract class TestRunner
+    {
+        public enum Jargon
+        {
+            TouchUnit,
+            NUnitV2,
+            NUnitV3,
+            xUnit,
+        }
+
+        public long InconclusiveTests { get; protected set; } = 0;
+        public long FailedTests { get; protected set; } = 0;
+        public long PassedTests { get; protected set; } = 0;
+        public long SkippedTests { get; protected set; } = 0;
+        public long ExecutedTests { get; protected set; } = 0;
+        public long TotalTests { get; protected set; } = 0;
+        public long FilteredTests { get; protected set; } = 0;
+        public bool RunInParallel { get; set; } = false;
+        public string TestsRootDirectory { get; set; }
+        public bool RunAllTestsByDefault { get; set; } = true;
+        public bool LogExcludedTests { get; set; }
+        public TextWriter Writer { get; set; }
+        public List<TestFailureInfo> FailureInfos { get; } = new List<TestFailureInfo>();
+
+        protected LogWriter Logger { get; }
+        protected abstract string ResultsFileName { get; set; }
+
+        protected TestRunner(LogWriter logger)
+        {
+            Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public abstract Task Run(IEnumerable<TestAssemblyInfo> testAssemblies);
+        public abstract string WriteResultsToFile(Jargon jargon);
+        public abstract void WriteResultsToFile(TextWriter writer, Jargon jargon);
+        public abstract void SkipTests(IEnumerable<string> tests);
+        public abstract void SkipCategories(IEnumerable<string> categories);
+
+        protected void OnError(string message)
+        {
+            Logger.OnError(message);
+        }
+
+        protected void OnWarning(string message)
+        {
+            Logger.OnWarning(message);
+        }
+
+        protected void OnDebug(string message)
+        {
+            Logger.OnDebug(message);
+        }
+
+        protected void OnDiagnostic(string message)
+        {
+            Logger.OnDiagnostic(message);
+        }
+
+        protected void OnInfo(string message)
+        {
+            Logger.OnInfo(message);
+        }
+
+        protected void OnAssemblyStart(Assembly asm)
+        {
+        }
+
+        protected void OnAssemblyFinish(Assembly asm)
+        {
+        }
+
+        protected void LogFailureSummary()
+        {
+            if (FailureInfos == null || FailureInfos.Count == 0)
+                return;
+
+            OnInfo("Failed tests:");
+            for (int i = 1; i <= FailureInfos.Count; i++)
+            {
+                TestFailureInfo info = FailureInfos[i - 1];
+                if (info == null || !info.HasInfo)
+                    continue;
+
+                OnInfo($"{i}) {info.Message}");
+            }
+        }
+
+        void AssertExecutionState(TestExecutionState state)
+        {
+            if (state == null)
+                throw new ArgumentNullException(nameof(state));
+        }
+
+        protected virtual string GetResultsFilePath()
+        {
+            if (String.IsNullOrEmpty(ResultsFileName))
+                throw new InvalidOperationException("Runner didn't specify a valid results file name");
+
+
+            string resultsPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            if (!Directory.Exists(resultsPath))
+                Directory.CreateDirectory(resultsPath);
+            return Path.Combine(resultsPath, ResultsFileName);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/IgnoreFileParser.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/IgnoreFileParser.cs
@@ -1,0 +1,137 @@
+using System.IO;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Reflection;
+using System;
+
+namespace Microsoft.DotNet.XHarness.iOS.TestRunner
+{
+
+    /// <summary>
+    /// Class that can parser a file/stream with the ignored tests and will
+    /// return a list of the ignored tests.
+    /// </summary>
+    public static class IgnoreFileParser
+    {
+
+        static string ParseLine(string line)
+        {
+            // we have to make sure of several things, first, lets
+            // remove any char after the first # which would mean
+            // we have comments:
+            var pos = line.IndexOf('#');
+            if (pos > -1)
+            {
+                line = line.Remove(pos);
+            }
+            line = line.Trim();
+            return line;
+        }
+        public static async Task<IEnumerable<string>> ParseStreamAsync(TextReader textReader)
+        {
+            var ignoredMethods = new List<string>();
+            string line;
+            while ((line = await textReader.ReadLineAsync()) != null)
+            {
+                // we have to make sure of several things, first, lets
+                // remove any char after the first # which would mean
+                // we have comments:
+                line = ParseLine(line);
+                if (string.IsNullOrEmpty(line))
+                    continue;
+                ignoredMethods.Add(line);
+            }
+            return ignoredMethods;
+        }
+
+        public static async Task<IEnumerable<string>> ParseAssemblyResourcesAsync(Assembly asm)
+        {
+            var ignoredTests = new List<string>();
+            // the project generator added the required resources,
+            // we extract them, parse them and add the result
+            foreach (var resourceName in asm.GetManifestResourceNames())
+            {
+                if (resourceName.EndsWith(".ignore", StringComparison.Ordinal))
+                {
+                    using (var stream = asm.GetManifestResourceStream(resourceName))
+                    using (var reader = new StreamReader(stream))
+                    {
+                        var ignored = await ParseStreamAsync(reader);
+                        // we could have more than one file, lets add them
+                        ignoredTests.AddRange(ignored);
+                    }
+                }
+            }
+            return ignoredTests;
+        }
+
+        public static async Task<IEnumerable<string>> ParseContentFilesAsync(string contentDir)
+        {
+            var ignoredTests = new List<string>();
+            foreach (var f in Directory.GetFiles(contentDir, "*.ignore"))
+            {
+                using (var reader = new StreamReader(f))
+                {
+                    var ignored = await ParseStreamAsync(reader);
+                    ignoredTests.AddRange(ignored);
+                }
+            }
+            return ignoredTests;
+        }
+
+        public static async Task<IEnumerable<string>> ParseTraitsContentFileAsync(string contentDir, bool isXUnit)
+        {
+            var ignoredTraits = new List<string>();
+            var ignoreFile = Path.Combine(contentDir, isXUnit ? "xunit-excludes.txt" : "nunit-excludes.txt");
+            using (var reader = new StreamReader(ignoreFile))
+            {
+                string line;
+                while ((line = await reader.ReadLineAsync()) != null)
+                {
+                    if (string.IsNullOrEmpty(line))
+                        continue;
+                    ignoredTraits.Add(line);
+                }
+            }
+            return ignoredTraits;
+        }
+
+        public static IEnumerable<string> ParseTraitsContentFile(string contentDir, bool isXUnit)
+        {
+            var ignoredTraits = new List<string>();
+            var ignoreFile = Path.Combine(contentDir, isXUnit ? "xunit-excludes.txt" : "nunit-excludes.txt");
+            using (var reader = new StreamReader(ignoreFile))
+            {
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    if (string.IsNullOrEmpty(line))
+                        continue;
+                    ignoredTraits.Add(line);
+                }
+            }
+            return ignoredTraits;
+        }
+
+        public static IEnumerable<string> ParseContentFiles(string contentDir)
+        {
+            var ignoredTests = new List<string>();
+            foreach (var f in Directory.GetFiles(contentDir, "*.ignore"))
+            {
+                using (var reader = new StreamReader(f))
+                {
+                    string line;
+                    while ((line = reader.ReadLine()) != null)
+                    {
+
+                        line = ParseLine(line);
+                        if (string.IsNullOrEmpty(line))
+                            continue;
+                        ignoredTests.Add(line);
+                    }
+                }
+            }
+            return ignoredTests;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Microsoft.DotNet.XHarness.iOS.TestRunner.csproj
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Microsoft.DotNet.XHarness.iOS.TestRunner.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.0;netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Microsoft.DotNet.XHarness.iOS.TestRunner.csproj
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/Microsoft.DotNet.XHarness.iOS.TestRunner.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="Core\" />
+    <Folder Include="xUnit\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="xUnit\NUnit3Xml.xslt" />
+    <None Remove="xUnit\NUnitXml.xslt" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="xUnit\NUnit3Xml.xslt">
+      <XlfSourceFormat></XlfSourceFormat>
+      <XlfOutputItem></XlfOutputItem>
+    </EmbeddedResource>
+    <EmbeddedResource Include="xUnit\NUnitXml.xslt">
+      <XlfSourceFormat></XlfSourceFormat>
+      <XlfOutputItem></XlfOutputItem>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit.analyzers" Version="0.10.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.utility" Version="2.4.1" />
+  </ItemGroup>
+</Project>

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/xUnit/NUnit3Xml.xslt
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/xUnit/NUnit3Xml.xslt
@@ -1,0 +1,204 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:testIdGenerator="urn:hash-generator">
+  <xsl:output cdata-section-elements="message stack-trace"/>
+
+  <xsl:template match="/">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <xsl:template match="assemblies">
+    <test-run name="Test results" fullname="Test results" inconclusive="0" asserts="0" id="2"> 
+      <!-- test-run attributes -->
+      <xsl:attribute name="testcasecount">
+        <xsl:value-of select="sum(assembly/@total)"/>
+      </xsl:attribute>
+      <xsl:attribute name="total">
+        <xsl:value-of select="sum(assembly/@total)"/>
+      </xsl:attribute>
+      <xsl:attribute name="passed">
+        <xsl:value-of select="sum(assembly/@passed)"/>
+      </xsl:attribute>
+      <xsl:attribute name="failed">
+        <xsl:value-of select="sum(assembly/@failed)"/>
+      </xsl:attribute>
+      <xsl:attribute name="skipped">
+        <xsl:value-of select="sum(assembly/@skipped)"/>
+      </xsl:attribute>
+      <xsl:attribute name="time">
+        <xsl:value-of select="sum(assembly/@time)"/>
+      </xsl:attribute>
+      <xsl:attribute name="run-date">
+        <xsl:value-of select="assembly[1]/@run-date"/>
+      </xsl:attribute>
+      <xsl:attribute name="start-time">
+        <xsl:value-of select="assembly[1]/@start-time"/>
+      </xsl:attribute>
+      <xsl:attribute name="result">
+        <xsl:if test="sum(assembly/@failed) > 0">Failed</xsl:if>
+        <xsl:if test="sum(assembly/@failed) = 0">Passed</xsl:if>
+      </xsl:attribute>
+      <!-- end of the test-run attributes -->
+      <environment os-version="unknown" platform="unknown" cwd="unknown" machine-name="unknown" user="unknown" user-domain="unknown">
+        <xsl:attribute name="nunit-version">
+          <xsl:value-of select="assembly[1]/@test-framework"/>
+        </xsl:attribute>
+        <xsl:attribute name="clr-version">
+          <xsl:value-of select="assembly[1]/@environment"/>
+        </xsl:attribute>
+      </environment>
+      <!-- failure element if any -->
+      <xsl:if test="sum(assembly/@failed) > 0">
+        <failure>
+          <message><![CDATA[Child test failed]]></message>
+        </failure>
+      </xsl:if>
+      <!-- end enviroment --> 
+      <!-- Add all the test-suite="Assembly" that maps to <assembly> in xunit -->
+      <xsl:apply-templates select="assembly"/>
+    </test-run>
+  </xsl:template>
+
+  <!-- Map Assembly to test-suite name="Assembly" -->
+  <xsl:template match="assembly">
+    <test-suite type="Assembly">
+      <xsl:attribute name="name">
+        <xsl:value-of select="@name"/>
+      </xsl:attribute>
+      <xsl:attribute name="testcasecount">
+        <xsl:value-of select="@total"/>
+      </xsl:attribute>
+      <xsl:attribute name="total">
+        <xsl:value-of select="@total"/>
+      </xsl:attribute>
+      <xsl:attribute name="passed">
+        <xsl:value-of select="@passed"/>
+      </xsl:attribute>
+      <xsl:attribute name="failed">
+        <xsl:value-of select="@failed"/>
+      </xsl:attribute>
+      <xsl:attribute name="skipped">
+        <xsl:value-of select="@skipped"/>
+      </xsl:attribute>
+      <xsl:attribute name="result">
+        <xsl:if test="@failed > 0">Failed</xsl:if>
+        <xsl:if test="@failed = 0">Passed</xsl:if>
+      </xsl:attribute>
+      <xsl:attribute name="time">
+        <xsl:value-of select="@time"/>
+      </xsl:attribute>
+      <!-- failure element if any -->
+       <xsl:if test="@failed > 0">
+        <failure>
+          <message><![CDATA[Child test failed]]></message>
+        </failure>
+      </xsl:if>
+      <xsl:apply-templates select="collection"/>
+    </test-suite>
+  </xsl:template>
+
+  <!-- Map colection to test-case name="TestFixture" -->
+  <xsl:template match="collection">
+    <xsl:param name="hash_source" select="@name"/>
+    <test-suite type="TestFixture" inconclusive="0">
+      <xsl:attribute name="name">
+        <xsl:value-of select="@name"/>
+      </xsl:attribute>
+      <xsl:attribute name="id">
+        <xsl:value-of select="testIdGenerator:GenerateHash($hash_source)"/>
+      </xsl:attribute>
+      <xsl:attribute name="testcasecount">
+        <xsl:value-of select="@total"/>
+      </xsl:attribute>
+      <xsl:attribute name="total">
+        <xsl:value-of select="@total"/>
+      </xsl:attribute>
+      <xsl:attribute name="result">
+        <xsl:if test="@failed > 0">Failed</xsl:if>
+        <xsl:if test="@failed = 0">Passed</xsl:if>
+      </xsl:attribute>
+      <xsl:attribute name="time">
+        <xsl:value-of select="@time"/>
+      </xsl:attribute>
+      <xsl:attribute name="passed">
+        <xsl:value-of select="@passed"/>
+      </xsl:attribute>
+      <xsl:attribute name="failed">
+        <xsl:value-of select="@failed"/>
+      </xsl:attribute>
+      <xsl:attribute name="skipped">
+        <xsl:value-of select="@skipped"/>
+      </xsl:attribute>
+
+      <!-- failure element if any -->
+       <xsl:if test="@failed > 0">
+        <failure>
+          <message><![CDATA[Child test failed]]></message>
+        </failure>
+      </xsl:if>
+      <xsl:apply-templates select="test"/>
+    </test-suite>
+  </xsl:template>
+
+  <!-- Map test to test-case -->
+
+  <xsl:template match="test">
+    <xsl:param name="hash_source" select="@name"/>
+    <test-case>
+      <xsl:attribute name="name">
+        <xsl:value-of select="@name"/>
+      </xsl:attribute>
+      <xsl:attribute name="fullname">
+        <xsl:value-of select="@name"/>
+      </xsl:attribute>
+      <xsl:attribute name="id">
+        <xsl:value-of select="testIdGenerator:GenerateHash($hash_source)"/>
+      </xsl:attribute>
+      <xsl:attribute name="result">
+        <xsl:if test="@result='Fail'">Failed</xsl:if>
+        <xsl:if test="@result='Pass'">Passed</xsl:if>
+        <xsl:if test="@result='Skip'">Skipped</xsl:if>
+      </xsl:attribute>
+      <xsl:if test="@time">
+        <xsl:attribute name="time">
+          <xsl:value-of select="@time"/>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates select="traits"/>
+      <xsl:if test="reason">
+        <reason>
+          <message>
+            <xsl:apply-templates select="reason"/>
+          </message>
+        </reason>
+      </xsl:if>
+      <xsl:apply-templates select="failure"/>
+    </test-case>
+  </xsl:template>
+
+  <!-- Map traits to properties -->
+  <xsl:template match="traits">
+    <properties>
+      <xsl:apply-templates select="trait"/>
+    </properties>
+  </xsl:template>
+
+  <!-- Map a single trait to a property -->
+  <xsl:template match="trait">
+    <property>
+      <xsl:attribute name="name">
+        <xsl:value-of select="@name"/>
+      </xsl:attribute>
+      <xsl:attribute name="value">
+        <xsl:value-of select="@value"/>
+      </xsl:attribute>
+    </property>
+  </xsl:template>
+
+  <!-- failures are the same -->
+  <xsl:template match="failure">
+    <failure>
+      <xsl:copy-of select="node()"/>
+    </failure>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/xUnit/NUnitXml.xslt
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/xUnit/NUnitXml.xslt
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output cdata-section-elements="message stack-trace"/>
+
+  <xsl:template match="/">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <xsl:template match="assemblies">
+    <test-results name="Test results" errors="0" inconclusive="0" ignored="0" invalid="0" not-run="0">
+      <xsl:attribute name="date">
+        <xsl:value-of select="assembly[1]/@run-date"/>
+      </xsl:attribute>
+      <xsl:attribute name="time">
+        <xsl:value-of select="assembly[1]/@run-time"/>
+      </xsl:attribute>
+      <xsl:attribute name="total">
+        <xsl:value-of select="sum(assembly/@total)"/>
+      </xsl:attribute>
+      <xsl:attribute name="failures">
+        <xsl:value-of select="sum(assembly/@failed)"/>
+      </xsl:attribute>
+      <xsl:attribute name="skipped">
+        <xsl:value-of select="sum(assembly/@skipped)"/>
+      </xsl:attribute>
+      <environment os-version="unknown" platform="unknown" cwd="unknown" machine-name="unknown" user="unknown" user-domain="unknown">
+        <xsl:attribute name="nunit-version">
+          <xsl:value-of select="assembly[1]/@test-framework"/>
+        </xsl:attribute>
+        <xsl:attribute name="clr-version">
+          <xsl:value-of select="assembly[1]/@environment"/>
+        </xsl:attribute>
+      </environment>
+      <culture-info current-culture="unknown" current-uiculture="unknown" />
+      <test-suite type="Assemblies" name="xUnit.net Tests" executed="True">
+        <xsl:attribute name="success">
+          <xsl:if test="sum(assembly/@failed) > 0">False</xsl:if>
+          <xsl:if test="sum(assembly/@failed) = 0">True</xsl:if>
+        </xsl:attribute>
+        <xsl:attribute name="result">
+          <xsl:if test="sum(assembly/@failed) > 0">Failure</xsl:if>
+          <xsl:if test="sum(assembly/@failed) = 0">Success</xsl:if>
+        </xsl:attribute>
+        <xsl:attribute name="time">
+          <xsl:value-of select="sum(assembly/@time)"/>
+        </xsl:attribute>
+        <results>
+          <xsl:apply-templates select="assembly"/>
+        </results>
+      </test-suite>
+    </test-results>
+  </xsl:template>
+
+  <xsl:template match="assembly">
+    <test-suite type="Assembly" executed="True">
+      <xsl:attribute name="name">
+        <xsl:value-of select="@name"/>
+      </xsl:attribute>
+      <xsl:attribute name="result">
+        <xsl:if test="@failed > 0">Failure</xsl:if>
+        <xsl:if test="@failed = 0">Success</xsl:if>
+      </xsl:attribute>
+      <xsl:attribute name="success">
+        <xsl:if test="@failed > 0">False</xsl:if>
+        <xsl:if test="@failed = 0">True</xsl:if>
+      </xsl:attribute>
+      <xsl:attribute name="time">
+        <xsl:value-of select="@time"/>
+      </xsl:attribute>
+      <results>
+        <xsl:apply-templates select="collection"/>
+      </results>
+    </test-suite>
+  </xsl:template>
+
+  <xsl:template match="collection">
+    <test-suite type="TestCollection" executed="True">
+      <xsl:attribute name="name">
+        <xsl:value-of select="@name"/>
+      </xsl:attribute>
+      <xsl:attribute name="result">
+        <xsl:if test="@failed > 0">Failure</xsl:if>
+        <xsl:if test="@failed = 0">Success</xsl:if>
+      </xsl:attribute>
+      <xsl:attribute name="success">
+        <xsl:if test="@failed > 0">False</xsl:if>
+        <xsl:if test="@failed = 0">True</xsl:if>
+      </xsl:attribute>
+      <xsl:attribute name="time">
+        <xsl:value-of select="@time"/>
+      </xsl:attribute>
+      <xsl:if test="failure">
+        <xsl:copy-of select="failure"/>
+      </xsl:if>
+      <xsl:if test="reason">
+        <reason>
+          <xsl:apply-templates select="reason"/>
+        </reason>
+      </xsl:if>
+      <results>
+        <xsl:apply-templates select="test"/>
+      </results>
+    </test-suite>
+  </xsl:template>
+
+  <xsl:template match="test">
+    <test-case>
+      <xsl:attribute name="name">
+        <xsl:value-of select="@name"/>
+      </xsl:attribute>
+      <xsl:attribute name="executed">
+        <xsl:if test="@result='Skip'">False</xsl:if>
+        <xsl:if test="@result!='Skip'">True</xsl:if>
+      </xsl:attribute>
+      <xsl:attribute name="result">
+        <xsl:if test="@result='Fail'">Failure</xsl:if>
+        <xsl:if test="@result='Pass'">Success</xsl:if>
+        <xsl:if test="@result='Skip'">Skipped</xsl:if>
+      </xsl:attribute>
+      <xsl:if test="@result!='Skip'">
+        <xsl:attribute name="success">
+          <xsl:if test="@result='Fail'">False</xsl:if>
+          <xsl:if test="@result='Pass'">True</xsl:if>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:if test="@time">
+        <xsl:attribute name="time">
+          <xsl:value-of select="@time"/>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates select="traits"/>
+      <xsl:if test="reason">
+        <reason>
+          <message>
+            <xsl:apply-templates select="reason"/>
+          </message>
+        </reason>
+      </xsl:if>
+      <xsl:apply-templates select="failure"/>
+    </test-case>
+  </xsl:template>
+
+  <xsl:template match="traits">
+    <properties>
+      <xsl:apply-templates select="trait"/>
+    </properties>
+  </xsl:template>
+
+  <xsl:template match="trait">
+    <property>
+      <xsl:attribute name="name">
+        <xsl:value-of select="@name"/>
+      </xsl:attribute>
+      <xsl:attribute name="value">
+        <xsl:value-of select="@value"/>
+      </xsl:attribute>
+    </property>
+  </xsl:template>
+
+  <xsl:template match="failure">
+    <failure>
+      <xsl:copy-of select="node()"/>
+    </failure>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/xUnit/XUnitFilter.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/xUnit/XUnitFilter.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Text;
+
+namespace Microsoft.DotNet.XHarness.iOS.TestRunner.XUnit
+{
+    public class XUnitFilter
+    {
+        public string AssemblyName { get; private set; }
+        public string SelectorName { get; private set; }
+        public string SelectorValue { get; private set; }
+
+        public bool Exclude { get; private set; }
+        public XUnitFilterType FilterType { get; private set; }
+
+        public static XUnitFilter CreateSingleFilter(string singleTestName, bool exclude, string assemblyName = null)
+        {
+            if (String.IsNullOrEmpty(singleTestName))
+                throw new ArgumentException("must not be null or empty", nameof(singleTestName));
+
+            return new XUnitFilter
+            {
+                AssemblyName = assemblyName,
+                SelectorValue = singleTestName,
+                FilterType = XUnitFilterType.Single,
+                Exclude = exclude
+            };
+        }
+
+        public static XUnitFilter CreateAssemblyFilter(string assemblyName, bool exclude)
+        {
+            if (String.IsNullOrEmpty(assemblyName))
+                throw new ArgumentException("must not be null or empty", nameof(assemblyName));
+
+            return new XUnitFilter
+            {
+                AssemblyName = assemblyName,
+                FilterType = XUnitFilterType.Assembly,
+                Exclude = exclude
+            };
+        }
+
+        public static XUnitFilter CreateNamespaceFilter(string namespaceName, bool exclude, string assemblyName = null)
+        {
+            if (String.IsNullOrEmpty(namespaceName))
+                throw new ArgumentException("must not be null or empty", nameof(namespaceName));
+
+            return new XUnitFilter
+            {
+                AssemblyName = assemblyName,
+                SelectorValue = namespaceName,
+                FilterType = XUnitFilterType.Namespace,
+                Exclude = exclude
+            };
+        }
+
+        public static XUnitFilter CreateClassFilter(string className, bool exclude, string assemblyName = null)
+        {
+            if (String.IsNullOrEmpty(className))
+                throw new ArgumentException("must not be null or empty", nameof(className));
+
+            return new XUnitFilter
+            {
+                AssemblyName = assemblyName,
+                SelectorValue = className,
+                FilterType = XUnitFilterType.TypeName,
+                Exclude = exclude
+            };
+        }
+
+        public static XUnitFilter CreateTraitFilter(string traitName, string traitValue, bool exclude)
+        {
+            if (String.IsNullOrEmpty(traitName))
+                throw new ArgumentException("must not be null or empty", nameof(traitName));
+
+            return new XUnitFilter
+            {
+                AssemblyName = null,
+                SelectorName = traitName,
+                SelectorValue = traitValue ?? String.Empty,
+                FilterType = XUnitFilterType.Trait,
+                Exclude = exclude
+            };
+        }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder("XUnitFilter [");
+
+            sb.Append($"Type: {FilterType}; ");
+            sb.Append(Exclude ? "exclude" : "include");
+
+            if (!String.IsNullOrEmpty(AssemblyName))
+                sb.Append($"; AssemblyName: {AssemblyName}");
+
+            switch (FilterType)
+            {
+                case XUnitFilterType.Assembly:
+                    break;
+
+                case XUnitFilterType.Namespace:
+                    AppendDesc("Namespace", SelectorValue);
+                    break;
+
+                case XUnitFilterType.Single:
+                    AppendDesc("Method", SelectorValue);
+                    break;
+
+                case XUnitFilterType.Trait:
+                    AppendDesc("Trait name", SelectorName);
+                    AppendDesc("Trait value", SelectorValue);
+                    break;
+
+                case XUnitFilterType.TypeName:
+                    AppendDesc("Class", SelectorValue);
+                    break;
+
+                default:
+                    sb.Append("; Unknown filter type");
+                    break;
+            }
+            sb.Append(']');
+
+            return sb.ToString();
+
+            void AppendDesc(string name, string value)
+            {
+                if (String.IsNullOrEmpty(value))
+                    return;
+
+                sb.Append($"; {name}: {value}");
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/xUnit/XUnitFilterType.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/xUnit/XUnitFilterType.cs
@@ -1,0 +1,11 @@
+namespace Microsoft.DotNet.XHarness.iOS.TestRunner.XUnit
+{
+    public enum XUnitFilterType
+    {
+        Trait,
+        TypeName,
+        Assembly,
+        Single,
+        Namespace,
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/xUnit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/xUnit/XUnitTestRunner.cs
@@ -26,7 +26,9 @@ namespace Microsoft.DotNet.XHarness.iOS.TestRunner.XUnit
     {
         readonly TestMessageSink messageSink;
 
-        XElement assembliesElement;
+        public int? MaxParallelThreads { get; set; }
+
+    XElement assembliesElement;
         List<XUnitFilter> filters = new List<XUnitFilter>();
         bool runAssemblyByDefault;
 
@@ -1004,7 +1006,7 @@ namespace Microsoft.DotNet.XHarness.iOS.TestRunner.XUnit
                     ITestFrameworkExecutionOptions executionOptions = GetFrameworkOptionsForExecution(configuration);
                     executionOptions.SetDisableParallelization(!RunInParallel);
                     executionOptions.SetSynchronousMessageReporting(true);
-                    executionOptions.SetMaxParallelThreads(Environment.ProcessorCount / 2); // lets not be greedy and let the UI breath.
+                    executionOptions.SetMaxParallelThreads(MaxParallelThreads); 
 
                     // set the wait for event cb first, then execute the tests
                     var resultTask = WaitForEvent(resultsSink.Finished, TimeSpan.FromDays(10)).ConfigureAwait(false);

--- a/src/Microsoft.DotNet.XHarness.iOS.TestRunner/xUnit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.TestRunner/xUnit/XUnitTestRunner.cs
@@ -1,0 +1,1160 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.Xsl;
+using Xunit;
+using Xunit.Abstractions;
+using Microsoft.DotNet.XHarness.iOS.TestRunner.Core;
+
+namespace Microsoft.DotNet.XHarness.iOS.TestRunner.XUnit
+{
+    public class XsltIdGenerator
+    {
+        // NUnit3 xml does not have schema, there is no much info about it, most examples just have incremental IDs.
+        int seed = 1000;
+        public int GenerateHash(string name) => seed++;
+    }
+
+    public class XUnitTestRunner : Core.TestRunner 
+    {
+        readonly TestMessageSink messageSink;
+
+        XElement assembliesElement;
+        List<XUnitFilter> filters = new List<XUnitFilter>();
+        bool runAssemblyByDefault;
+
+        public AppDomainSupport AppDomainSupport { get; set; } = AppDomainSupport.Denied;
+        protected override string ResultsFileName { get; set; } = "TestResults.xUnit.xml";
+
+        public XUnitTestRunner(LogWriter logger) : base(logger)
+        {
+            messageSink = new TestMessageSink();
+
+            messageSink.Diagnostics.DiagnosticMessageEvent += HandleDiagnosticMessage;
+            messageSink.Diagnostics.ErrorMessageEvent += HandleDiagnosticErrorMessage;
+
+            messageSink.Discovery.DiscoveryCompleteMessageEvent += HandleDiscoveryCompleteMessage;
+            messageSink.Discovery.TestCaseDiscoveryMessageEvent += HandleDiscoveryTestCaseMessage;
+
+            messageSink.Runner.TestAssemblyDiscoveryFinishedEvent += HandleTestAssemblyDiscoveryFinished;
+            messageSink.Runner.TestAssemblyDiscoveryStartingEvent += HandleTestAssemblyDiscoveryStarting;
+            messageSink.Runner.TestAssemblyExecutionFinishedEvent += HandleTestAssemblyExecutionFinished;
+            messageSink.Runner.TestAssemblyExecutionStartingEvent += HandleTestAssemblyExecutionStarting;
+            messageSink.Runner.TestExecutionSummaryEvent += HandleTestExecutionSummary;
+
+            messageSink.Execution.AfterTestFinishedEvent += (MessageHandlerArgs<IAfterTestFinished> args) => HandleEvent("AfterTestFinishedEvent", args, HandleAfterTestFinished);
+            messageSink.Execution.AfterTestStartingEvent += (MessageHandlerArgs<IAfterTestStarting> args) => HandleEvent("AfterTestStartingEvent", args, HandleAfterTestStarting);
+            messageSink.Execution.BeforeTestFinishedEvent += (MessageHandlerArgs<IBeforeTestFinished> args) => HandleEvent("BeforeTestFinishedEvent", args, HandleBeforeTestFinished);
+            messageSink.Execution.BeforeTestStartingEvent += (MessageHandlerArgs<IBeforeTestStarting> args) => HandleEvent("BeforeTestStartingEvent", args, HandleBeforeTestStarting);
+            messageSink.Execution.TestAssemblyCleanupFailureEvent += (MessageHandlerArgs<ITestAssemblyCleanupFailure> args) => HandleEvent("TestAssemblyCleanupFailureEvent", args, HandleTestAssemblyCleanupFailure);
+            messageSink.Execution.TestAssemblyFinishedEvent += (MessageHandlerArgs<ITestAssemblyFinished> args) => HandleEvent("TestAssemblyFinishedEvent", args, HandleTestAssemblyFinished);
+            messageSink.Execution.TestAssemblyStartingEvent += (MessageHandlerArgs<ITestAssemblyStarting> args) => HandleEvent("TestAssemblyStartingEvent", args, HandleTestAssemblyStarting);
+            messageSink.Execution.TestCaseCleanupFailureEvent += (MessageHandlerArgs<ITestCaseCleanupFailure> args) => HandleEvent("TestCaseCleanupFailureEvent", args, HandleTestCaseCleanupFailure);
+            messageSink.Execution.TestCaseFinishedEvent += (MessageHandlerArgs<ITestCaseFinished> args) => HandleEvent("TestCaseFinishedEvent", args, HandleTestCaseFinished);
+            messageSink.Execution.TestCaseStartingEvent += (MessageHandlerArgs<ITestCaseStarting> args) => HandleEvent("TestStartingEvent", args, HandleTestCaseStarting);
+            messageSink.Execution.TestClassCleanupFailureEvent += (MessageHandlerArgs<ITestClassCleanupFailure> args) => HandleEvent("TestClassCleanupFailureEvent", args, HandleTestClassCleanupFailure);
+            messageSink.Execution.TestClassConstructionFinishedEvent += (MessageHandlerArgs<ITestClassConstructionFinished> args) => HandleEvent("TestClassConstructionFinishedEvent", args, HandleTestClassConstructionFinished);
+            messageSink.Execution.TestClassConstructionStartingEvent += (MessageHandlerArgs<ITestClassConstructionStarting> args) => HandleEvent("TestClassConstructionStartingEvent", args, HandleTestClassConstructionStarting);
+            messageSink.Execution.TestClassDisposeFinishedEvent += (MessageHandlerArgs<ITestClassDisposeFinished> args) => HandleEvent("TestClassDisposeFinishedEvent", args, HandleTestClassDisposeFinished);
+            messageSink.Execution.TestClassDisposeStartingEvent += (MessageHandlerArgs<ITestClassDisposeStarting> args) => HandleEvent("TestClassDisposeStartingEvent", args, HandleTestClassDisposeStarting);
+            messageSink.Execution.TestClassFinishedEvent += (MessageHandlerArgs<ITestClassFinished> args) => HandleEvent("TestClassFinishedEvent", args, HandleTestClassFinished);
+            messageSink.Execution.TestClassStartingEvent += (MessageHandlerArgs<ITestClassStarting> args) => HandleEvent("TestClassStartingEvent", args, HandleTestClassStarting);
+            messageSink.Execution.TestCleanupFailureEvent += (MessageHandlerArgs<ITestCleanupFailure> args) => HandleEvent("TestCleanupFailureEvent", args, HandleTestCleanupFailure);
+            messageSink.Execution.TestCollectionCleanupFailureEvent += (MessageHandlerArgs<ITestCollectionCleanupFailure> args) => HandleEvent("TestCollectionCleanupFailureEvent", args, HandleTestCollectionCleanupFailure);
+            messageSink.Execution.TestCollectionFinishedEvent += (MessageHandlerArgs<ITestCollectionFinished> args) => HandleEvent("TestCollectionFinishedEvent", args, HandleTestCollectionFinished);
+            messageSink.Execution.TestCollectionStartingEvent += (MessageHandlerArgs<ITestCollectionStarting> args) => HandleEvent("TestCollectionStartingEvent", args, HandleTestCollectionStarting);
+            messageSink.Execution.TestFailedEvent += (MessageHandlerArgs<ITestFailed> args) => HandleEvent("TestFailedEvent", args, HandleTestFailed);
+            messageSink.Execution.TestFinishedEvent += (MessageHandlerArgs<ITestFinished> args) => HandleEvent("TestFinishedEvent", args, HandleTestFinished);
+            messageSink.Execution.TestMethodCleanupFailureEvent += (MessageHandlerArgs<ITestMethodCleanupFailure> args) => HandleEvent("TestMethodCleanupFailureEvent", args, HandleTestMethodCleanupFailure);
+            messageSink.Execution.TestMethodFinishedEvent += (MessageHandlerArgs<ITestMethodFinished> args) => HandleEvent("TestMethodFinishedEvent", args, HandleTestMethodFinished);
+            messageSink.Execution.TestMethodStartingEvent += (MessageHandlerArgs<ITestMethodStarting> args) => HandleEvent("TestMethodStartingEvent", args, HandleTestMethodStarting);
+            messageSink.Execution.TestOutputEvent += (MessageHandlerArgs<ITestOutput> args) => HandleEvent("TestOutputEvent", args, HandleTestOutput);
+            messageSink.Execution.TestPassedEvent += (MessageHandlerArgs<ITestPassed> args) => HandleEvent("TestPassedEvent", args, HandleTestPassed);
+            messageSink.Execution.TestSkippedEvent += (MessageHandlerArgs<ITestSkipped> args) => HandleEvent("TestSkippedEvent", args, HandleTestSkipped);
+            messageSink.Execution.TestStartingEvent += (MessageHandlerArgs<ITestStarting> args) => HandleEvent("TestStartingEvent", args, HandleTestStarting);
+        }
+
+        public void AddFilter(XUnitFilter filter)
+        {
+            if (filter != null)
+            {
+                filters.Add(filter);
+            }
+        }
+        public void SetFilters(List<XUnitFilter> newFilters)
+        {
+            if (newFilters == null)
+            {
+                filters = null;
+                return;
+            }
+
+            if (filters == null)
+                filters = new List<XUnitFilter>();
+
+            filters.AddRange(newFilters);
+        }
+
+        void HandleEvent<T>(string name, MessageHandlerArgs<T> args, Action<MessageHandlerArgs<T>> actualHandler) where T : class, IMessageSinkMessage
+        {
+            try
+            {
+                actualHandler(args);
+            }
+            catch (Exception ex)
+            {
+                OnError($"Handler for event {name} failed with exception");
+                OnError(ex.ToString());
+            }
+        }
+
+        void HandleTestStarting(MessageHandlerArgs<ITestStarting> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnDebug("Test starting");
+            LogTestDetails(args.Message.Test, log: OnDebug);
+            ReportTestCases("   Associated", args.Message.TestCases, args.Message.TestCase, OnDiagnostic);
+        }
+
+        void HandleTestSkipped(MessageHandlerArgs<ITestSkipped> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            SkippedTests++;
+            OnInfo($"\t[IGNORED] {args.Message.TestCase.DisplayName}");
+            LogTestDetails(args.Message.Test, log: OnDebug);
+            LogTestOutput(args.Message, log: OnDiagnostic);
+            ReportTestCases("   Associated", args.Message.TestCases, log: OnDiagnostic);
+        }
+
+        void HandleTestPassed(MessageHandlerArgs<ITestPassed> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            PassedTests++;
+            OnInfo($"\t[PASS] {args.Message.TestCase.DisplayName}");
+            LogTestDetails(args.Message.Test, log: OnDebug);
+            LogTestOutput(args.Message, log: OnDiagnostic);
+            ReportTestCases("   Associated", args.Message.TestCases, log: OnDiagnostic);
+        }
+
+        void HandleTestOutput(MessageHandlerArgs<ITestOutput> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnInfo(args.Message.Output);
+        }
+
+        void HandleTestMethodStarting(MessageHandlerArgs<ITestMethodStarting> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnDebug("Test method starting");
+            LogTestMethodDetails(args.Message.TestMethod.Method, log: OnDebug);
+            LogTestClassDetails(args.Message.TestMethod.TestClass, log: OnDebug);
+            ReportTestCases("   Associated", args.Message.TestCases, log: OnDiagnostic);
+        }
+
+        void HandleTestMethodFinished(MessageHandlerArgs<ITestMethodFinished> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnDebug("Test method finished");
+            LogTestMethodDetails(args.Message.TestMethod.Method, log: OnDebug);
+            LogTestClassDetails(args.Message.TestMethod.TestClass, log: OnDebug);
+            LogSummary(args.Message, log: OnDebug);
+            ReportTestCases("   Associated", args.Message.TestCases, log: OnDiagnostic);
+        }
+
+        void HandleTestMethodCleanupFailure(MessageHandlerArgs<ITestMethodCleanupFailure> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnError($"Test method cleanup failure{GetAssemblyInfo(args.Message.TestAssembly)}");
+            LogTestMethodDetails(args.Message.TestMethod.Method, log: OnError);
+            LogTestClassDetails(args.Message.TestMethod.TestClass, log: OnError);
+            ReportTestCases("   Associated", args.Message.TestCases, log: OnDiagnostic);
+            LogFailureInformation(args.Message, log: OnError);
+        }
+
+        void HandleTestFinished(MessageHandlerArgs<ITestFinished> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            ExecutedTests++;
+            OnDiagnostic("Test finished");
+            LogTestDetails(args.Message.Test, log: OnDiagnostic);
+            LogTestOutput(args.Message, log: OnDiagnostic);
+            ReportTestCases("   Associated", args.Message.TestCases, args.Message.TestCase, OnDiagnostic);
+        }
+
+        void HandleTestFailed(MessageHandlerArgs<ITestFailed> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            FailedTests++;
+            string assemblyInfo = GetAssemblyInfo(args.Message.TestAssembly);
+            var sb = new StringBuilder($"\t[FAIL] {args.Message.TestCase.DisplayName}");
+            LogTestDetails(args.Message.Test, OnError, sb);
+            sb.AppendLine();
+            if (!string.IsNullOrEmpty(assemblyInfo))
+                sb.AppendLine($"   Assembly: {assemblyInfo}");
+            LogSourceInformation(args.Message.TestCase.SourceInformation, OnError, sb);
+            LogFailureInformation(args.Message, OnError, sb);
+            sb.AppendLine();
+            LogTestOutput(args.Message, OnError, sb);
+            sb.AppendLine();
+            if (args.Message.TestCase.Traits != null && args.Message.TestCase.Traits.Count > 0)
+            {
+                foreach (var kvp in args.Message.TestCase.Traits)
+                {
+                    string message = $"   Test trait name: {kvp.Key}";
+                    OnError(message);
+                    sb.AppendLine(message);
+
+                    foreach (string v in kvp.Value)
+                    {
+                        message = $"      value: {v}";
+                        OnError(message);
+                        sb.AppendLine(message);
+                    }
+                }
+                sb.AppendLine();
+            }
+            ReportTestCases("   Associated", args.Message.TestCases, args.Message.TestCase, OnDiagnostic);
+
+            FailureInfos.Add(new TestFailureInfo
+            {
+                TestName = args.Message.Test?.DisplayName,
+                Message = sb.ToString()
+            });
+            OnInfo($"\t[FAIL] {args.Message.Test.TestCase.DisplayName}");
+            OnInfo(sb.ToString());
+        }
+
+        void HandleTestCollectionStarting(MessageHandlerArgs<ITestCollectionStarting> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnInfo($"\n{args.Message.TestCollection.DisplayName}");
+            OnDebug("Test collection starting");
+            LogTestCollectionDetails(args.Message.TestCollection, log: OnDebug);
+            ReportTestCases("   Associated", args.Message.TestCases, log: OnDiagnostic);
+        }
+
+        void HandleTestCollectionFinished(MessageHandlerArgs<ITestCollectionFinished> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnDebug("Test collection finished");
+            LogSummary(args.Message, log: OnDebug);
+            LogTestCollectionDetails(args.Message.TestCollection, log: OnDebug);
+            ReportTestCases("   Associated", args.Message.TestCases, log: OnDiagnostic);
+        }
+
+        void HandleTestCollectionCleanupFailure(MessageHandlerArgs<ITestCollectionCleanupFailure> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnError("Error during test collection cleanup");
+            LogTestCollectionDetails(args.Message.TestCollection, log: OnError);
+            ReportTestCases("   Associated", args.Message.TestCases, log: OnError);
+            LogFailureInformation(args.Message, log: OnError);
+        }
+
+        void HandleTestCleanupFailure(MessageHandlerArgs<ITestCleanupFailure> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnError($"Test cleanup failure{GetAssemblyInfo(args.Message.TestAssembly)}");
+            LogTestDetails(args.Message.Test, log: OnError);
+            ReportTestCases("   Associated", args.Message.TestCases, log: OnError);
+            LogFailureInformation(args.Message, log: OnError);
+        }
+
+        void HandleTestClassStarting(MessageHandlerArgs<ITestClassStarting> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnDiagnostic("Test class starting");
+            LogTestClassDetails(args.Message.TestClass, log: OnDiagnostic);
+        }
+
+        void HandleTestClassFinished(MessageHandlerArgs<ITestClassFinished> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnDebug("Test class finished");
+            OnInfo($"{args.Message.TestClass.Class.Name} {args.Message.ExecutionTime} ms");
+            LogTestClassDetails(args.Message.TestClass, OnDebug);
+            ReportTestCases("   Associated", args.Message.TestCases, log: OnDiagnostic);
+        }
+
+        void HandleTestClassDisposeStarting(MessageHandlerArgs<ITestClassDisposeStarting> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnDiagnostic("Test class dispose starting");
+            LogTestDetails(args.Message.Test, log: OnDiagnostic);
+            ReportTestCases("   Associated", args.Message.TestCases, log: OnDiagnostic);
+        }
+
+        void HandleTestClassDisposeFinished(MessageHandlerArgs<ITestClassDisposeFinished> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnDiagnostic("Test class dispose finished");
+            LogTestDetails(args.Message.Test, log: OnDiagnostic);
+            ReportTestCases("   Associated", args.Message.TestCases, log: OnDiagnostic);
+        }
+
+        void HandleTestClassConstructionStarting(MessageHandlerArgs<ITestClassConstructionStarting> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnDiagnostic("Test class construction starting");
+            LogTestDetails(args.Message.Test, OnDiagnostic);
+            ReportTestCases("   Associated", args.Message.TestCases, args.Message.TestCase, OnDiagnostic);
+        }
+
+        void HandleTestClassConstructionFinished(MessageHandlerArgs<ITestClassConstructionFinished> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnDiagnostic("Test class construction finished");
+            LogTestDetails(args.Message.Test, log: OnDiagnostic);
+            ReportTestCases("   Associated", args.Message.TestCases, args.Message.TestCase, OnDiagnostic);
+        }
+
+        void HandleTestClassCleanupFailure(MessageHandlerArgs<ITestClassCleanupFailure> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnError($"Test class cleanup error{GetAssemblyInfo(args.Message.TestAssembly)}");
+            LogTestClassDetails(args.Message.TestClass, log: OnError);
+            LogTestCollectionDetails(args.Message.TestCollection, log: OnError);
+            ReportTestCases("   Associated", args.Message.TestCases, log: OnError);
+            LogFailureInformation(args.Message, log: OnError);
+        }
+
+        void HandleTestCaseStarting(MessageHandlerArgs<ITestCaseStarting> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnDiagnostic("Test case starting");
+            ReportTestCase("   Starting", args.Message.TestCase, log: OnDiagnostic);
+            ReportTestCases("   Associated", args.Message.TestCases, args.Message.TestCase, OnDiagnostic);
+        }
+
+        void HandleTestCaseFinished(MessageHandlerArgs<ITestCaseFinished> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnDebug("Test case finished executing");
+            ReportTestCase("   Finished", args.Message.TestCase, log: OnDebug);
+            ReportTestCases("   Associated", args.Message.TestCases, args.Message.TestCase, OnDebug);
+            LogSummary(args.Message, log: OnDebug);
+        }
+
+        void HandleTestCaseCleanupFailure(MessageHandlerArgs<ITestCaseCleanupFailure> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnError("Test case cleanup failure");
+            ReportTestCase("   Failed", args.Message.TestCase, log: OnError);
+            ReportTestCases("   Associated", args.Message.TestCases, args.Message.TestCase, OnError);
+            LogFailureInformation(args.Message, log: OnError);
+        }
+
+        void HandleTestAssemblyStarting(MessageHandlerArgs<ITestAssemblyStarting> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnInfo($"[Test environment: {args.Message.TestEnvironment}]");
+            OnInfo($"[Test framework: {args.Message.TestFrameworkDisplayName}]");
+            LogAssemblyInformation(args.Message, log: OnDebug);
+            ReportTestCases("   Associated", args.Message.TestCases, log: OnDebug);
+        }
+
+        void HandleTestAssemblyFinished(MessageHandlerArgs<ITestAssemblyFinished> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            TotalTests = args.Message.TestsRun; // HACK: We are not counting correctly all the tests
+            OnDebug("Execution process for assembly finished");
+            LogAssemblyInformation(args.Message, log: OnDebug);
+            LogSummary(args.Message, log: OnDebug);
+            ReportTestCases("   Associated", args.Message.TestCases, log: OnDiagnostic);
+        }
+
+        void HandleTestAssemblyCleanupFailure(MessageHandlerArgs<ITestAssemblyCleanupFailure> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnError("Assembly cleanup failure");
+            LogAssemblyInformation(args.Message, OnError);
+            ReportTestCases("   Associated", args.Message.TestCases, log: OnError);
+            LogFailureInformation(args.Message, log: OnError);
+        }
+
+        void HandleBeforeTestStarting(MessageHandlerArgs<IBeforeTestStarting> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnDiagnostic($"'Before' method for test '{args.Message.Test.DisplayName}' starting");
+        }
+
+        void HandleBeforeTestFinished(MessageHandlerArgs<IBeforeTestFinished> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnDiagnostic($"'Before' method for test '{args.Message.Test.DisplayName}' finished");
+        }
+
+        void HandleAfterTestStarting(MessageHandlerArgs<IAfterTestStarting> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnDiagnostic($"'After' method for test '{args.Message.Test.DisplayName}' starting");
+        }
+
+        void HandleAfterTestFinished(MessageHandlerArgs<IAfterTestFinished> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnDiagnostic($"'After' method for test '{args.Message.Test.DisplayName}' finished");
+        }
+
+        void HandleTestExecutionSummary(MessageHandlerArgs<ITestExecutionSummary> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnInfo("All tests finished");
+            OnInfo($"    Elapsed time: {args.Message.ElapsedClockTime}");
+
+            if (args.Message.Summaries == null || args.Message.Summaries.Count == 0)
+                return;
+
+            foreach (KeyValuePair<string, ExecutionSummary> summary in args.Message.Summaries)
+            {
+                OnInfo(String.Empty);
+                OnInfo($" Assembly: {summary.Key}");
+                LogSummary(summary.Value, log: OnDebug);
+            }
+        }
+
+        void HandleTestAssemblyExecutionStarting(MessageHandlerArgs<ITestAssemblyExecutionStarting> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnInfo($"Execution starting for assembly {args.Message.Assembly.AssemblyFilename}");
+        }
+
+        void HandleTestAssemblyExecutionFinished(MessageHandlerArgs<ITestAssemblyExecutionFinished> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnInfo($"Execution finished for assembly {args.Message.Assembly.AssemblyFilename}");
+            LogSummary(args.Message.ExecutionSummary, log: OnDebug);
+        }
+
+        void HandleTestAssemblyDiscoveryStarting(MessageHandlerArgs<ITestAssemblyDiscoveryStarting> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnInfo($"Discovery for assembly {args.Message.Assembly.AssemblyFilename} starting");
+            OnInfo($"   Will use AppDomain: {args.Message.AppDomain.YesNo()}");
+        }
+
+        void HandleTestAssemblyDiscoveryFinished(MessageHandlerArgs<ITestAssemblyDiscoveryFinished> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnInfo($"Discovery for assembly {args.Message.Assembly.AssemblyFilename} finished");
+            OnInfo($"   Test cases discovered: {args.Message.TestCasesDiscovered}");
+            OnInfo($"   Test cases to run: {args.Message.TestCasesToRun}");
+        }
+
+        void HandleDiagnosticMessage(MessageHandlerArgs<IDiagnosticMessage> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnDiagnostic(args.Message.Message);
+        }
+
+        void HandleDiagnosticErrorMessage(MessageHandlerArgs<IErrorMessage> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            LogFailureInformation(args.Message);
+        }
+
+        void HandleDiscoveryCompleteMessage(MessageHandlerArgs<IDiscoveryCompleteMessage> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            OnInfo("Discovery complete");
+        }
+
+        void HandleDiscoveryTestCaseMessage(MessageHandlerArgs<ITestCaseDiscoveryMessage> args)
+        {
+            if (args == null || args.Message == null)
+                return;
+
+            ITestCase singleTestCase = args.Message.TestCase;
+            ReportTestCases("Discovered", args.Message.TestCases, log: OnInfo, ignore: (ITestCase tc) => tc == singleTestCase);
+            ReportTestCase("Discovered", singleTestCase, log: OnInfo);
+        }
+
+        void ReportTestCases(string verb, IEnumerable<ITestCase> testCases, ITestCase ignoreTestCase, Action<string> log = null)
+        {
+            ReportTestCases(verb, testCases, log, (ITestCase tc) => ignoreTestCase == tc);
+        }
+
+        void ReportTestCases(string verb, IEnumerable<ITestCase> testCases, Action<string> log = null, Func<ITestCase, bool> ignore = null)
+        {
+            if (testCases == null)
+                return;
+
+            foreach (ITestCase tc in testCases)
+            {
+                if (ignore != null && ignore(tc))
+                    continue;
+                ReportTestCase(verb, tc, log);
+            }
+        }
+
+        void ReportTestCase(string verb, ITestCase testCase, Action<string> log = null)
+        {
+            if (testCase == null)
+                return;
+
+            EnsureLogger(log)($"{verb} test case: {testCase.DisplayName}");
+        }
+
+        void LogAssemblyInformation(ITestAssemblyMessage message, Action<string> log = null, StringBuilder sb = null)
+        {
+            if (message == null)
+                return;
+
+            do_log($"[Assembly name: {message.TestAssembly.Assembly.Name}]", log, sb);
+            do_log($"[Assembly path: {message.TestAssembly.Assembly.AssemblyPath}]", OnDiagnostic, sb);
+        }
+
+        void LogFailureInformation(IFailureInformation info, Action<string> log = null, StringBuilder sb = null)
+        {
+            if (info == null)
+                return;
+
+            string message = ExceptionUtility.CombineMessages(info);
+            do_log($"   Exception messages: {message}", log, sb);
+
+            string traces = ExceptionUtility.CombineStackTraces(info);
+            do_log($"   Exception stack traces: {traces}", log, sb);
+        }
+
+        Action<string> EnsureLogger(Action<string> log)
+        {
+            return log ?? OnInfo;
+        }
+
+        void LogTestMethodDetails(IMethodInfo method, Action<string> log = null, StringBuilder sb = null)
+        {
+            log = EnsureLogger(log);
+
+            //log ($"   Test method name: {method.Type.Name}.{method.Name}");
+        }
+
+        void LogTestOutput(ITestFinished test, Action<string> log = null, StringBuilder sb = null)
+        {
+            LogTestOutput(test.ExecutionTime, test.Output, log, sb);
+        }
+
+        void LogTestOutput(ITestResultMessage test, Action<string> log = null, StringBuilder sb = null)
+        {
+            LogTestOutput(test.ExecutionTime, test.Output, log, sb);
+        }
+
+        void LogTestOutput(decimal executionTime, string output, Action<string> log = null, StringBuilder sb = null)
+        {
+            do_log($"   Execution time: {executionTime}", log, sb);
+            if (!String.IsNullOrEmpty(output))
+            {
+                do_log(" **** Output start ****", log, sb);
+                foreach (string line in output.Split('\n'))
+                    do_log(line, log, sb);
+                do_log(" **** Output end ****", log, sb);
+            }
+        }
+
+        void LogTestCollectionDetails(ITestCollection collection, Action<string> log = null, StringBuilder sb = null)
+        {
+            do_log($"   Test collection: {collection.DisplayName}", log, sb);
+        }
+
+        void LogTestClassDetails(ITestClass klass, Action<string> log = null, StringBuilder sb = null)
+        {
+            do_log($"   Class name: {klass.Class.Name}", log, sb);
+            do_log($"   Class assembly: {klass.Class.Assembly.Name}", OnDebug, sb);
+            do_log($"   Class assembly path: {klass.Class.Assembly.AssemblyPath}", OnDebug, sb);
+        }
+
+        void LogTestDetails(ITest test, Action<string> log = null, StringBuilder sb = null)
+        {
+            do_log($"   Test name: {test.DisplayName}", log, sb);
+            if (String.Compare(test.DisplayName, test.TestCase.DisplayName, StringComparison.Ordinal) != 0)
+                do_log($"   Test case: {test.TestCase.DisplayName}", log, sb);
+        }
+
+        void LogSummary(IFinishedMessage summary, Action<string> log = null, StringBuilder sb = null)
+        {
+            do_log($"   Time: {summary.ExecutionTime}", log, sb);
+            do_log($"   Total tests run: {summary.TestsRun}", log, sb);
+            do_log($"   Skipped tests: {summary.TestsSkipped}", log, sb);
+            do_log($"   Failed tests: {summary.TestsFailed}", log, sb);
+        }
+
+        void LogSummary(ExecutionSummary summary, Action<string> log = null, StringBuilder sb = null)
+        {
+            do_log($"   Time: {summary.Time}", log, sb);
+            do_log($"   Total tests run: {summary.Total}", log, sb);
+            do_log($"   Total errors: {summary.Errors}", log, sb);
+            do_log($"   Skipped tests: {summary.Skipped}", log, sb);
+            do_log($"   Failed tests: {summary.Failed}", log, sb);
+        }
+
+        void LogSourceInformation(ISourceInformation source, Action<string> log = null, StringBuilder sb = null)
+        {
+            if (source == null || String.IsNullOrEmpty(source.FileName))
+                return;
+
+            string location = source.FileName;
+            if (source.LineNumber != null && source.LineNumber >= 0)
+                location += $":{source.LineNumber}";
+
+            do_log($"   Source: {location}", log, sb);
+            sb?.AppendLine();
+        }
+
+        string GetAssemblyInfo(ITestAssembly assembly)
+        {
+            string name = assembly?.Assembly?.Name?.Trim();
+            if (String.IsNullOrEmpty(name))
+                return name;
+            return $" [{name}]";
+        }
+
+        void do_log(string message, Action<string> log = null, StringBuilder sb = null)
+        {
+            log = EnsureLogger(log);
+
+            if (sb != null)
+                sb.Append(message);
+            log(message);
+        }
+
+        static async Task WaitForEvent(WaitHandle handle, TimeSpan timeout)
+        {
+            var tcs = new TaskCompletionSource<object>();
+            var registration = ThreadPool.RegisterWaitForSingleObject(handle, (_, timedOut) =>
+            {
+                if (timedOut)
+                    tcs.TrySetCanceled();
+                else
+                    tcs.TrySetResult(null);
+            }, tcs, timeout, true);
+
+            try
+            {
+                if (!tcs.Task.IsCompleted)
+                    await tcs.Task.ConfigureAwait(false);
+            }
+            finally
+            {
+                registration.Unregister(handle);
+            }
+        }
+
+        public override async Task Run(IEnumerable<TestAssemblyInfo> testAssemblies)
+        {
+            if (testAssemblies == null)
+                throw new ArgumentNullException(nameof(testAssemblies));
+
+            if (filters != null && filters.Count > 0)
+            {
+                do_log("Configured filters:");
+                foreach (XUnitFilter filter in filters)
+                {
+                    do_log($"  {filter}");
+                }
+            }
+
+            List<XUnitFilter> assemblyFilters = filters?.Where(sel => sel != null && sel.FilterType == XUnitFilterType.Assembly)?.ToList();
+            if (assemblyFilters == null || assemblyFilters.Count == 0)
+            {
+                runAssemblyByDefault = true;
+                assemblyFilters = null;
+            }
+            else
+                runAssemblyByDefault = assemblyFilters.Any(f => f != null && f.Exclude);
+
+            assembliesElement = new XElement("assemblies");
+            foreach (TestAssemblyInfo assemblyInfo in testAssemblies)
+            {
+                if (assemblyInfo == null || assemblyInfo.Assembly == null || !ShouldRunAssembly(assemblyInfo))
+                    continue;
+
+                if (String.IsNullOrEmpty(assemblyInfo.FullPath))
+                {
+                    OnWarning($"Assembly '{assemblyInfo.Assembly}' cannot be found on the filesystem. xUnit requires access to actual on-disk file.");
+                    continue;
+                }
+
+                OnInfo($"Assembly: {assemblyInfo.Assembly} ({assemblyInfo.FullPath})");
+                XElement assemblyElement = null;
+                try
+                {
+                    OnAssemblyStart(assemblyInfo.Assembly);
+                    assemblyElement = await Run(assemblyInfo.Assembly, assemblyInfo.FullPath).ConfigureAwait(false);
+                }
+                catch (FileNotFoundException ex)
+                {
+                    OnWarning($"Assembly '{assemblyInfo.Assembly}' using path '{assemblyInfo.FullPath}' cannot be found on the filesystem. xUnit requires access to actual on-disk file.");
+                    OnWarning($"Exception is '{ex}'");
+                }
+                finally
+                {
+                    OnAssemblyFinish(assemblyInfo.Assembly);
+                    if (assemblyElement != null)
+                        assembliesElement.Add(assemblyElement);
+                }
+            }
+
+            LogFailureSummary();
+            TotalTests += FilteredTests; // ensure that we do have in the total run the excluded ones.
+
+            bool ShouldRunAssembly(TestAssemblyInfo assemblyInfo)
+            {
+                if (assemblyInfo == null)
+                    return false;
+
+                if (assemblyFilters == null)
+                    return true;
+
+                foreach (XUnitFilter filter in assemblyFilters)
+                {
+                    if (String.Compare(filter.AssemblyName, assemblyInfo.FullPath, StringComparison.Ordinal) == 0)
+                        return ReportFilteredAssembly(assemblyInfo, filter);
+
+                    string fileName = Path.GetFileName(assemblyInfo.FullPath);
+                    if (String.Compare(fileName, filter.AssemblyName, StringComparison.Ordinal) == 0)
+                        return ReportFilteredAssembly(assemblyInfo, filter);
+
+                    string filterExtension = Path.GetExtension(filter.AssemblyName);
+                    if (String.IsNullOrEmpty(filterExtension) ||
+                        (String.Compare(filterExtension, ".exe", StringComparison.OrdinalIgnoreCase) != 0 &&
+                         String.Compare(filterExtension, ".dll", StringComparison.OrdinalIgnoreCase) != 0))
+                    {
+                        string asmName = $"{filter.AssemblyName}.dll";
+                        if (String.Compare(asmName, fileName, StringComparison.Ordinal) == 0)
+                            return ReportFilteredAssembly(assemblyInfo, filter);
+
+                        asmName = $"{filter.AssemblyName}.exe";
+                        if (String.Compare(asmName, fileName, StringComparison.Ordinal) == 0)
+                            return ReportFilteredAssembly(assemblyInfo, filter);
+                    }
+                }
+
+                return runAssemblyByDefault;
+            }
+
+            bool ReportFilteredAssembly(TestAssemblyInfo assemblyInfo, XUnitFilter filter)
+            {
+                if (LogExcludedTests)
+                {
+                    const string included = "Included";
+                    const string excluded = "Excluded";
+
+                    OnInfo($"[FILTER] {(filter.Exclude ? excluded : included)} assembly: {assemblyInfo.FullPath}");
+                }
+                return !filter.Exclude;
+            }
+        }
+
+        public override string WriteResultsToFile(Jargon jargon)
+        {
+            if (assembliesElement == null)
+                return String.Empty;
+            // remove all the empty nodes
+            assembliesElement.Descendants().Where(e => e.Name == "collection" && !e.Descendants().Any()).Remove();
+            string outputFilePath = GetResultsFilePath();
+            var settings = new XmlWriterSettings { Indent = true };
+            using (var xmlWriter = XmlWriter.Create(outputFilePath, settings))
+            {
+                switch (jargon)
+                {
+                    case Jargon.NUnitV2:
+                        Transform_Results("NUnitXml.xslt", assembliesElement, xmlWriter);
+                        break;
+                    case Jargon.NUnitV3:
+                        Transform_Results("NUnit3Xml.xslt", assembliesElement, xmlWriter);
+                        break;
+                    default: // default to xunit until we implement NUnit v3 support.
+                        assembliesElement.Save(xmlWriter);
+                        break;
+                }
+            }
+
+            return outputFilePath;
+        }
+        public override void WriteResultsToFile(TextWriter writer, Jargon jargon)
+        {
+            if (assembliesElement == null)
+                return;
+            // remove all the empty nodes
+            assembliesElement.Descendants().Where(e => e.Name == "collection" && !e.Descendants().Any()).Remove();
+            var settings = new XmlWriterSettings { Indent = true };
+            using (var xmlWriter = XmlWriter.Create(writer, settings))
+            {
+                switch (jargon)
+                {
+                    case Jargon.NUnitV2:
+                        try
+                        {
+                            Transform_Results("NUnitXml.xslt", assembliesElement, xmlWriter);
+                        }
+                        catch (Exception e)
+                        {
+                            writer.WriteLine(e);
+                        }
+                        break;
+                    case Jargon.NUnitV3:
+                        try
+                        {
+                            Transform_Results("NUnit3Xml.xslt", assembliesElement, xmlWriter);
+                        }
+                        catch (Exception e)
+                        {
+                            writer.WriteLine(e);
+                        }
+                        break;
+                    default: // defualt to xunit until we add NUnitv3 support
+                        assembliesElement.Save(xmlWriter);
+                        break;
+                }
+            }
+        }
+
+        void Transform_Results(string xsltResourceName, XElement element, XmlWriter writer)
+        {
+            var xmlTransform = new System.Xml.Xsl.XslCompiledTransform();
+            var name = GetType().Assembly.GetManifestResourceNames().Where(a => a.EndsWith(xsltResourceName, StringComparison.Ordinal)).FirstOrDefault();
+            if (name == null)
+                return;
+            using (var xsltStream = GetType().Assembly.GetManifestResourceStream(name))
+            {
+                if (xsltStream == null)
+                {
+                    throw new Exception($"Stream with name {name} cannot be found! We have {GetType().Assembly.GetManifestResourceNames()[0]}");
+                }
+                // add the extension so that we can get the hash from the name of the test
+                // Create an XsltArgumentList.
+                XsltArgumentList xslArg = new XsltArgumentList();
+
+                var generator = new XsltIdGenerator();
+                xslArg.AddExtensionObject("urn:hash-generator", generator);
+
+                using (var xsltReader = XmlReader.Create(xsltStream))
+                using (var xmlReader = element.CreateReader())
+                {
+                    xmlTransform.Load(xsltReader);
+                    xmlTransform.Transform(xmlReader, xslArg, writer);
+                }
+            }
+        }
+
+        protected virtual Stream GetConfigurationFileStream(Assembly assembly)
+        {
+            if (assembly == null)
+                throw new ArgumentNullException(nameof(assembly));
+
+            string path = assembly.Location?.Trim();
+            if (String.IsNullOrEmpty(path))
+                return null;
+
+            path = Path.Combine(path, ".xunit.runner.json");
+            if (!File.Exists(path))
+                return null;
+
+            return File.OpenRead(path);
+        }
+
+        protected virtual TestAssemblyConfiguration GetConfiguration(Assembly assembly)
+        {
+            if (assembly == null)
+                throw new ArgumentNullException(nameof(assembly));
+
+            Stream configStream = GetConfigurationFileStream(assembly);
+            if (configStream != null)
+            {
+                using (configStream)
+                {
+                    return ConfigReader.Load(configStream);
+                }
+            }
+
+            return null;
+        }
+
+        protected virtual ITestFrameworkDiscoveryOptions GetFrameworkOptionsForDiscovery(TestAssemblyConfiguration configuration)
+        {
+            if (configuration == null)
+                throw new ArgumentNullException(nameof(configuration));
+
+            return TestFrameworkOptions.ForDiscovery(configuration);
+        }
+
+        protected virtual ITestFrameworkExecutionOptions GetFrameworkOptionsForExecution(TestAssemblyConfiguration configuration)
+        {
+            if (configuration == null)
+                throw new ArgumentNullException(nameof(configuration));
+
+            return TestFrameworkOptions.ForExecution(configuration);
+        }
+
+        async Task<XElement> Run(Assembly assembly, string assemblyPath)
+        {
+            using (var frontController = new XunitFrontController(AppDomainSupport, assemblyPath, null, false))
+            {
+                using (var discoverySink = new TestDiscoverySink())
+                {
+                    var configuration = GetConfiguration(assembly) ?? new TestAssemblyConfiguration();
+                    ITestFrameworkDiscoveryOptions discoveryOptions = GetFrameworkOptionsForDiscovery(configuration);
+                    discoveryOptions.SetSynchronousMessageReporting(true);
+                    Logger.OnDebug($"Starting test discovery in the '{assembly}' assembly");
+                    frontController.Find(false, discoverySink, discoveryOptions);
+                    Logger.OnDebug($"Test discovery in assembly '{assembly}' completed");
+                    discoverySink.Finished.WaitOne();
+
+                    if (discoverySink.TestCases == null || discoverySink.TestCases.Count == 0)
+                    {
+                        Logger.Info("No test cases discovered");
+                        return null;
+                    }
+
+                    TotalTests += discoverySink.TestCases.Count;
+                    List<ITestCase> testCases;
+                    if (filters != null && filters.Count > 0)
+                    {
+                        testCases = discoverySink.TestCases.Where(tc => IsIncluded(tc)).ToList();
+                        FilteredTests += discoverySink.TestCases.Count - testCases.Count;
+                    }
+                    else
+                        testCases = discoverySink.TestCases;
+
+                    var assemblyElement = new XElement("assembly");
+                    IExecutionSink resultsSink = new DelegatingExecutionSummarySink(messageSink, null, null);
+                    resultsSink = new DelegatingXmlCreationSink(resultsSink, assemblyElement);
+                    ITestFrameworkExecutionOptions executionOptions = GetFrameworkOptionsForExecution(configuration);
+                    executionOptions.SetDisableParallelization(!RunInParallel);
+                    executionOptions.SetSynchronousMessageReporting(true);
+                    executionOptions.SetMaxParallelThreads(Environment.ProcessorCount / 2); // lets not be greedy and let the UI breath.
+
+                    // set the wait for event cb first, then execute the tests
+                    var resultTask = WaitForEvent(resultsSink.Finished, TimeSpan.FromDays(10)).ConfigureAwait(false);
+                    frontController.RunTests(testCases, resultsSink, executionOptions);
+                    await resultTask;
+
+                    return assemblyElement;
+                }
+            }
+        }
+
+        bool IsIncluded(ITestCase testCase)
+        {
+            if (testCase == null)
+                return false;
+
+            bool haveTraits = testCase.Traits != null && testCase.Traits.Count > 0;
+            foreach (XUnitFilter filter in filters)
+            {
+                List<string> values;
+                if (filter == null)
+                    continue;
+
+                if (filter.FilterType == XUnitFilterType.Trait)
+                {
+                    if (!haveTraits || !testCase.Traits.TryGetValue(filter.SelectorName, out values))
+                        continue;
+
+                    if (values == null || values.Count == 0)
+                    {
+                        // We have no values and the filter doesn't specify one - that means we match on
+                        // the trait name only.
+                        if (String.IsNullOrEmpty(filter.SelectorValue))
+                            return ReportFilteredTest(filter);
+                        continue;
+                    }
+
+                    if (values.Contains(filter.SelectorValue, StringComparer.OrdinalIgnoreCase))
+                        return ReportFilteredTest(filter);
+                    continue;
+                }
+
+                if (filter.FilterType == XUnitFilterType.TypeName)
+                {
+                    string testClassName = testCase.TestMethod?.TestClass?.Class?.Name?.Trim();
+                    if (String.IsNullOrEmpty(testClassName))
+                        continue;
+
+                    if (String.Compare(testClassName, filter.SelectorValue, StringComparison.OrdinalIgnoreCase) == 0)
+                        return ReportFilteredTest(filter);
+                    continue;
+                }
+
+                if (filter.FilterType == XUnitFilterType.Single)
+                {
+                    if (String.Compare(testCase.DisplayName, filter.SelectorValue, StringComparison.OrdinalIgnoreCase) == 0)
+                        return ReportFilteredTest(filter);
+                    continue;
+                }
+
+                if (filter.FilterType == XUnitFilterType.Namespace)
+                {
+                    string testClassName = testCase.TestMethod?.TestClass?.Class?.Name?.Trim();
+                    if (String.IsNullOrEmpty(testClassName))
+                        continue;
+
+                    int dot = testClassName.LastIndexOf('.');
+                    if (dot <= 0)
+                        continue;
+
+                    string testClassNamespace = testClassName.Substring(0, dot);
+                    if (String.Compare(testClassNamespace, filter.SelectorValue, StringComparison.OrdinalIgnoreCase) == 0)
+                        return ReportFilteredTest(filter);
+                    continue;
+                }
+
+                if (filter.FilterType == XUnitFilterType.Assembly)
+                {
+                    continue; // Ignored: handled elsewhere
+                }
+
+                throw new InvalidOperationException($"Unsupported filter type {filter.FilterType}");
+            }
+
+            return RunAllTestsByDefault;
+
+            bool ReportFilteredTest(XUnitFilter filter)
+            {
+                if (LogExcludedTests)
+                {
+                    const string included = "Included";
+                    const string excluded = "Excluded";
+
+                    string selector;
+                    if (filter.FilterType == XUnitFilterType.Trait)
+                        selector = $"'{filter.SelectorName}':'{filter.SelectorValue}'";
+                    else
+                        selector = $"'{filter.SelectorValue}'";
+
+                    do_log($"[FILTER] {(filter.Exclude ? excluded : included)} test (filtered by {filter.FilterType}; {selector}): {testCase.DisplayName}");
+                }
+                return !filter.Exclude;
+            }
+        }
+
+        public override void SkipTests(IEnumerable<string> tests)
+        {
+            if (tests.Any())
+            {
+                // create a single filter per test
+                foreach (var t in tests)
+                {
+                    if (t.StartsWith("KLASS:", StringComparison.Ordinal))
+                    {
+                        var klass = t.Replace("KLASS:", "");
+                        filters.Add(XUnitFilter.CreateClassFilter(klass, true));
+                    }
+                    else if (t.StartsWith("KLASS32:", StringComparison.Ordinal) && IntPtr.Size == 4)
+                    {
+                        var klass = t.Replace("KLASS32:", "");
+                        filters.Add(XUnitFilter.CreateClassFilter(klass, true));
+                    }
+                    else if (t.StartsWith("KLASS64:", StringComparison.Ordinal) && IntPtr.Size == 8)
+                    {
+                        var klass = t.Replace("KLASS32:", "");
+                        filters.Add(XUnitFilter.CreateClassFilter(klass, true));
+                    }
+                    else if (t.StartsWith("Platform32:", StringComparison.Ordinal) && IntPtr.Size == 4)
+                    {
+                        var filter = t.Replace("Platform32:", "");
+                        filters.Add(XUnitFilter.CreateSingleFilter(filter, true));
+                    }
+                    else
+                    {
+                        filters.Add(XUnitFilter.CreateSingleFilter(t, true));
+                    }
+                }
+            }
+        }
+
+        public override void SkipCategories(IEnumerable<string> categories)
+        {
+            if (categories.Any())
+            {
+                foreach (var c in categories)
+                {
+                    var traitInfo = c.Split('=');
+                    filters.Add(XUnitFilter.CreateTraitFilter(traitInfo[0], traitInfo[1], true));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Provide the basic iOS runner for possible clients. The API provides an
entry point class that will perform all the required initialization
expected by xharness and will run the tests.

Clients must inherit from ApplicationEntryPoint and implement the
following properties/methods. Later call RunAsync, for example, in
ViewDidLoad.

*protected abstract IDevice Device { get; }*

Must return an object that implements the interface. The following code
is an example of the implementation using Xamarin.iOS.

```csharp
public class XamarinIOSExample : IDevice
{
  UIDevice device = UIDevice.CurrentDevice;

  public string BundleIdentifier => NSBundle.MainBundle.BundleIdentifier;

  public string UniqueIdentifier {
  {
    get {
    IntPtr handle = UIDevice.CurrentDevice.Handle;
    if (UIDevice.CurrentDevice.RespondsToSelector (new Selector ("uniqueIdentifier")))
      return NSString.FromHandle (objc_msgSend (handle, Selector.GetHandle("uniqueIdentifier")));
    return "unknown";
  }

  public string Name => device.Name;
  public string Model => device.Model;
  public string SystemName => device.SystemName;
  public string SystemVersion => device.SystemVersion;
  public string Locale => NSLocale.CurrentLocale.Identifier;
}

```

*protected abstract TestRunner TestRunner { get; }*

Simply state the type of runner to use.

*protected abstract string IgnoreFilesDirectory { get; }*

Return the location in which traits and ignores have been added. The
patterns are as follow:

* ignore files: Files with the pattern *.ignore
* trait files: There are two available file names:
  - xunit-excludes.txt: For the traits to be ignored by the xunit
  runner.
  - nunit-excludes.txt: For the categories to be ignored inthe nunit
  runner.

*protected abstract void TerminateWithSuccess();*

Should terminate the app with a valid result. Example:

```csharp
void InternalTerminateWithSuccess ()
{
  // For WatchOS we're terminating the extension, not the watchos app itself.
  Console.WriteLine ("Exiting test run with success");
  Selector s = new Selector ("terminateWithSuccess");
  UIApplication.SharedApplication.PerformSelector (s, UIApplication.SharedApplication, 0);
}

public override void TerminateWithSuccess()
{
  BeginInvokeOnMainThread (TerminateWithSuccess);
}

```

Notes: This API is not set in stone.